### PR TITLE
Buildbot gets dev image build

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -278,7 +278,7 @@ ubiquity_lxde.addStep(steps.ShellCommand(command=["/usr/bin/sha256sum", compress
 #ubiquity_lxde.addStep(steps.FileUpload(name="Upload Image", workersrc=compressed_image_file, masterdest=compressed_image_master_dest))
 
 c['builders'].append(
-    util.BuilderConfig(name="pi-lxde-image",
+    util.BuilderConfig(name="pi-lxde-xenial-image",
       workernames=["boron"],
       factory=ubiquity_lxde))
 
@@ -303,7 +303,7 @@ ubiquity_lxde.addStep(steps.ShellCommand(command=["/usr/bin/sha256sum", compress
 #ubiquity_lxde.addStep(steps.FileUpload(name="Upload Image", workersrc=compressed_image_file, masterdest=compressed_image_master_dest))
 
 c['builders'].append(
-    util.BuilderConfig(name="pi-lxde-testing-image",
+    util.BuilderConfig(name="pi-lxde-xenial-testing-image",
       workernames=["boron"],
       factory=ubiquity_lxde))
 

--- a/master.cfg
+++ b/master.cfg
@@ -313,33 +313,57 @@ c['schedulers'].append(
                        builderNames=['pi-lxde-testing-image'],
                        dayOfWeek=0, hour=0, minute=1))
 
-ubiquity_lxde = util.BuildFactory()
-ubiquity_lxde.addStep(steps.Git(repourl='https://'+creds.buildbot_github_token+'@github.com/UbiquityRobotics/pi_image2.git', mode='incremental'))
+ubiquity_base = util.BuildFactory()
+ubiquity_base.addStep(steps.Git(repourl='https://'+creds.buildbot_github_token+'@github.com/UbiquityRobotics/pi_image2.git', mode='incremental'))
 # first need to install debootstrap and pychroot - TODO do this in the buldbot image template so we dont have to do it everytime here
-ubiquity_lxde.addStep(steps.ShellCommand(command= ["sudo", "apt-get", "install", "python3-pip", "debootstrap", "-y"], description="Install pip and chroot", name="Install pip and chroot", timeout=4000))
-ubiquity_lxde.addStep(steps.ShellCommand(command= ["sudo", "pip3", "install", "pychroot"], description="Install chroot", name="Install chroot", timeout=4000))
-ubiquity_lxde.addStep(steps.ShellCommand(command= ["sudo", "python3", "build_image.py", "--config_path", "focal-test-build-settings.yaml"], description="Building", name="Run Build Script", timeout=4000))
-ubiquity_lxde.addStep(steps.SetPropertyFromCommand(command="cat latest_image", property="latest_image_path", haltOnFailure=True))
+ubiquity_base.addStep(steps.ShellCommand(command= ["sudo", "apt-get", "install", "python3-pip", "debootstrap", "-y"], description="Install pip and chroot", name="Install pip and chroot", timeout=4000))
+ubiquity_base.addStep(steps.ShellCommand(command= ["sudo", "pip3", "install", "pychroot"], description="Install chroot", name="Install chroot", timeout=4000))
+ubiquity_base.addStep(steps.ShellCommand(command= ["sudo", "python3", "build_image.py", "--config_path", "focal-test-build-settings.yaml"], description="Building", name="Run Build Script", timeout=4000))
+ubiquity_base.addStep(steps.SetPropertyFromCommand(command="cat latest_image", property="latest_image_path", haltOnFailure=True))
 compressed_image_file = util.Interpolate('%s.xz', util.Property('latest_image_path'))
 image_name = util.Transform(os.path.basename, util.Property('latest_image_path'))
 compressed_image_name = util.Interpolate('%s.xz', image_name)
 compressed_image_master_dest = util.Interpolate('/buildwork/%s.xz', image_name)
 
 upload_url = util.Transform(generate_image_upload_url, compressed_image_name)
-ubiquity_lxde.addStep(steps.ShellCommand(command=["/usr/bin/curl", "-H", "x-amz-acl: public-read", upload_url, "--upload-file", compressed_image_file]))
-ubiquity_lxde.addStep(steps.ShellCommand(command=["/usr/bin/sha256sum", compressed_image_file]))
-ubiquity_lxde.addStep(steps.FileUpload(name="Upload Image", workersrc=compressed_image_file, masterdest=compressed_image_master_dest))
+ubiquity_base.addStep(steps.ShellCommand(command=["/usr/bin/curl", "-H", "x-amz-acl: public-read", upload_url, "--upload-file", compressed_image_file]))
+ubiquity_base.addStep(steps.ShellCommand(command=["/usr/bin/sha256sum", compressed_image_file]))
+ubiquity_base.addStep(steps.FileUpload(name="Upload Image", workersrc=compressed_image_file, masterdest=compressed_image_master_dest))
 
 c['builders'].append(
-    util.BuilderConfig(name="pi-lxde-focal-testing-image",
+    util.BuilderConfig(name="pi-base-focal-testing-image",
       workernames=["boron"],
-      factory=ubiquity_lxde))
+      factory=ubiquity_base))
 
 # Weekly testing image built at midnight UTC every monday
-c['schedulers'].append(
-    schedulers.Nightly(name='weekly-focal-testing-image',
-                       builderNames=['pi-lxde-focal-testing-image'],
-                       dayOfWeek=0, hour=0, minute=1))
+# c['schedulers'].append(
+#     schedulers.Nightly(name='weekly-focal-testing-image',
+#                        builderNames=['pi-base-focal-testing-image'],
+#                        dayOfWeek=0, hour=0, minute=1))
+
+
+
+ubiquity_gdb = util.BuildFactory()
+ubiquity_gdb.addStep(steps.Git(repourl='https://'+creds.buildbot_github_token+'@github.com/UbiquityRobotics/pi_image2.git', mode='incremental'))
+# first need to install debootstrap and pychroot - TODO do this in the buldbot image template so we dont have to do it everytime here
+ubiquity_gdb.addStep(steps.ShellCommand(command= ["sudo", "apt-get", "install", "python3-pip", "debootstrap", "-y"], description="Install pip and chroot", name="Install pip and chroot", timeout=4000))
+ubiquity_gdb.addStep(steps.ShellCommand(command= ["sudo", "pip3", "install", "pychroot"], description="Install chroot", name="Install chroot", timeout=4000))
+ubiquity_gdb.addStep(steps.ShellCommand(command= ["sudo", "python3", "build_image.py", "--config_path", "focal-dev-build-settings.yaml"], description="Building", name="Run Build Script", timeout=4000))
+ubiquity_gdb.addStep(steps.SetPropertyFromCommand(command="cat latest_image", property="latest_image_path", haltOnFailure=True))
+compressed_image_file = util.Interpolate('%s.xz', util.Property('latest_image_path'))
+image_name = util.Transform(os.path.basename, util.Property('latest_image_path'))
+compressed_image_name = util.Interpolate('%s.xz', image_name)
+compressed_image_master_dest = util.Interpolate('/buildwork/%s.xz', image_name)
+
+upload_url = util.Transform(generate_image_upload_url, compressed_image_name)
+ubiquity_gdb.addStep(steps.ShellCommand(command=["/usr/bin/curl", "-H", "x-amz-acl: public-read", upload_url, "--upload-file", compressed_image_file]))
+ubiquity_gdb.addStep(steps.ShellCommand(command=["/usr/bin/sha256sum", compressed_image_file]))
+ubiquity_gdb.addStep(steps.FileUpload(name="Upload Image", workersrc=compressed_image_file, masterdest=compressed_image_master_dest))
+
+c['builders'].append(
+    util.BuilderConfig(name="pi-gdm3-focal-dev-image",
+      workernames=["boron"],
+      factory=ubiquity_gdb))
 
 
 pifi_deb = util.BuildFactory()


### PR DESCRIPTION
Added dev image builder, removed weekly builds for test image, added more sensible names to builder: 

 - `pi-gdm3-focal-dev-image` is going to be focal with desktop environment
 - `pi-lxde-focal-testing-image` is now `base-focal-testing-image` since it does not contain lxde. This is eventually going to be stripped also of other unnncesseary stuff and become a "true" base image, but untill that is done, this is at least more base then dev. 
 - `pi-lxde-testing-image` is now  `pi-lxde-xenial-testing-image` and `pi-lxde-image` is now `pi-lxde-xenial-image` since now the focal builders are also going to be added.

This is currently deployed on buildbot so you can see it also on https://build.ubiquityrobotics.com/#/

**Also a question**: does it make sense to run a weekly build for `pi-lxde-xenial-testing-image`? This is probably eating away our aws credits without much use to us.